### PR TITLE
[NCL-6094] Use Java 1.8 source and target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <tagSuffix />
     </properties>
     <dependencies>


### PR DESCRIPTION
Other services like Orcha are still on Java 1.8, untill all are on 11
we need to keep the api compatible