### PR TITLE
Remove forgotten @NotNull annotation

### DIFF
--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/Artifact.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/Artifact.java
@@ -56,7 +56,6 @@ public class Artifact {
 
     private final String pncId;
 
-    @NotNull
     private final ArtifactType artifactType;
 
     @NotBlank

--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/Build.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/Build.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Positive;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;


### PR DESCRIPTION
When artifact type is null, the artifact is de/serialized as Artifact class itself