### PR TITLE
[NCL-6695] Add operationId to the AnalyzePayload for the DeliverablesAnalysis; add OperationStatus and operationId to the AnalysisResponse after a DeliverableAnalyzer operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Eclipse
 .project
+.factorypath
 .classpath
 .settings/
 bin/

--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalysisReport.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalysisReport.java
@@ -43,7 +43,7 @@ public class AnalysisReport implements Serializable {
     private List<FinderResult> results;
 
     /** Flag indicating if analysis was finished successfully */
-    private  boolean success;
+    private boolean success;
 
     /** Root cause of the analysis failure (if analysis failed) */
     private Throwable errorCause;

--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalysisResponse.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalysisResponse.java
@@ -1,0 +1,25 @@
+package org.jboss.pnc.api.deliverablesanalyzer.dto;
+
+import org.jboss.pnc.api.enums.OperationStatus;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Jacksonized
+@Builder(builderClassName = "Builder")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AnalysisResponse {
+
+    @NonNull
+    private final OperationStatus status;
+    @NonNull
+    private final String operationId;
+    @NonNull
+    private final AnalysisResult analysisResult;
+
+}

--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalyzePayload.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalyzePayload.java
@@ -32,6 +32,11 @@ import org.jboss.pnc.api.dto.Request;
 @Jacksonized
 @Builder
 public class AnalyzePayload implements Serializable {
+
+    private static final long serialVersionUID = -2043312712105992478L;
+
+    private String operationId;
+
     private List<String> urls;
 
     private String config;

--- a/src/main/java/org/jboss/pnc/api/enums/OperationStatus.java
+++ b/src/main/java/org/jboss/pnc/api/enums/OperationStatus.java
@@ -1,0 +1,29 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.api.enums;
+
+/**
+ * Status of a running/completed Operation.
+ * 
+ * The OperationStatus class is used by all the Operation sub-classes (e.g. DeliverablesAnalyzerOperation)
+ *
+ */
+public enum OperationStatus {
+
+    NEW, IN_PROGRESS, SUCCESSFUL, FAILED, CANCELLED, TIMEOUT, SYSTEM_ERROR;
+}


### PR DESCRIPTION
The operationId is propagated from the Orchestrator (which stores a DeliverableAnalyzerOperation in the DB) to BPM and then to the DeliverableAnalyzer