### PR TITLE
[NCL-6695] Add OperationResult and ProgressStatus enums; Add operationId to the AnalyzePayload for the DeliverablesAnalysis; add OperationResult and operationId to the AnalysisResponse after a DeliverableAnalyzer operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Eclipse
 .project
+.factorypath
 .classpath
 .factorypath
 .settings/

--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalysisResponse.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalysisResponse.java
@@ -1,0 +1,25 @@
+package org.jboss.pnc.api.deliverablesanalyzer.dto;
+
+import org.jboss.pnc.api.enums.OperationResult;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Jacksonized
+@Builder(builderClassName = "Builder")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AnalysisResponse {
+
+    @NonNull
+    private final OperationResult status;
+    @NonNull
+    private final String operationId;
+    @NonNull
+    private final AnalysisResult analysisResult;
+
+}

--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalyzePayload.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalyzePayload.java
@@ -32,6 +32,11 @@ import org.jboss.pnc.api.dto.Request;
 @Jacksonized
 @Builder
 public class AnalyzePayload implements Serializable {
+
+    private static final long serialVersionUID = -2043312712105992478L;
+
+    private String operationId;
+
     private List<String> urls;
 
     private String config;

--- a/src/main/java/org/jboss/pnc/api/enums/BuildProgress.java
+++ b/src/main/java/org/jboss/pnc/api/enums/BuildProgress.java
@@ -19,9 +19,11 @@ package org.jboss.pnc.api.enums;
 
 /**
  * Enum describing build progress.
- * 
+ *
+ * @deprecated Use {@link ProgressStatus}
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
+@Deprecated
 public enum BuildProgress {
     /**
      * The build is waiting.

--- a/src/main/java/org/jboss/pnc/api/enums/OperationResult.java
+++ b/src/main/java/org/jboss/pnc/api/enums/OperationResult.java
@@ -1,0 +1,53 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.api.enums;
+
+/**
+ * Status of a completed Operation.
+ *
+ * The OperationResult class is used by all the Operation sub-classes (e.g. DeliverablesAnalyzerOperation)
+ *
+ */
+public enum OperationResult {
+
+    /**
+     * The operation completed successfully.
+     */
+    SUCCESSFUL,
+    /**
+     * The operation failed because of reasons unrelated to the systems. For example user provided parameters resulted
+     * in unsuccessful outcome.
+     */
+    FAILED,
+    /**
+     * Execution of the operation was rejected.
+     */
+    REJECTED,
+    /**
+     * The operation was cancelled by user before it was finished.
+     */
+    CANCELLED,
+    /**
+     * The operation did not receive response from a system for long time.
+     */
+    TIMEOUT,
+    /**
+     * The operation failed because of issue in the systems. For example bug or network error was encountered.
+     */
+    SYSTEM_ERROR;
+}

--- a/src/main/java/org/jboss/pnc/api/enums/ProgressStatus.java
+++ b/src/main/java/org/jboss/pnc/api/enums/ProgressStatus.java
@@ -18,23 +18,26 @@
 package org.jboss.pnc.api.enums;
 
 /**
- * Enum describing job progress in notifications.
+ * Status of progress of a running/completed operation.
  *
- * @deprecated Use {@link ProgressStatus}
- * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ *
  */
-@Deprecated
-public enum JobNotificationProgress {
+public enum ProgressStatus {
+
     /**
-     * The job is waiting. For example build waiting for dependencies.
+     * Initial status of an operation.
+     */
+    NEW,
+    /**
+     * The operation is waiting. For example build waiting for dependencies.
      */
     PENDING,
     /**
-     * The job is running. For example build is building.
+     * The operation is running. For example build is building.
      */
     IN_PROGRESS,
     /**
-     * The job has finished. For example build failed.
+     * The operation has finished. For example build failed.
      */
-    FINISHED
+    FINISHED;
 }


### PR DESCRIPTION
Reimplementation of https://github.com/project-ncl/pnc-api/pull/56