### PR TITLE
[NCLSUP-792] Add scm tag information in the clone

### DIFF
--- a/src/main/java/org/jboss/pnc/api/builddriver/dto/BuildRequest.java
+++ b/src/main/java/org/jboss/pnc/api/builddriver/dto/BuildRequest.java
@@ -37,6 +37,7 @@ public class BuildRequest {
     private final String projectName;
     private final String scmUrl;
     private final String scmRevision;
+    private final String scmTag;
     private final String command;
     private final String workingDirectory;
     private final String environmentBaseUrl;


### PR DESCRIPTION
We need this information to be allowed to do a shallow clone of the git repository. We want to do a shallow clone to speed up git cloning.