### PR TITLE
[Alignment 2.0] rename Version to QualifiedVersion

### DIFF
--- a/src/main/java/org/jboss/pnc/api/dependencyanalyzer/dto/QualifiedVersion.java
+++ b/src/main/java/org/jboss/pnc/api/dependencyanalyzer/dto/QualifiedVersion.java
@@ -14,25 +14,25 @@ import java.util.Set;
 @Getter
 @Builder
 @ToString
-public class Version {
+public class QualifiedVersion {
 
     private final String version;
 
     @Singular
     private final Map<Qualifier, Set<String>> qualifiers;
 
-    public Version(String version, Map<Qualifier, Set<String>> qualifiers) {
+    public QualifiedVersion(String version, Map<Qualifier, Set<String>> qualifiers) {
         this.version = version;
         this.qualifiers = qualifiers;
     }
 
-    public Version(String version) {
+    public QualifiedVersion(String version) {
         this.version = version;
         this.qualifiers = new HashMap<>();
     }
 
-    public static Version of(String version) {
-        return new Version(version);
+    public static QualifiedVersion of(String version) {
+        return new QualifiedVersion(version);
     }
 
     public boolean has(Qualifier qualifier, String[] values) {


### PR DESCRIPTION
Rename Version class to QualifiedVersion class to better convey the function of the class. (suggested by @janinko)