### PR TITLE
[NCL-7921] Add annotations to influence request

### DIFF
--- a/src/main/java/org/jboss/pnc/api/dto/Request.java
+++ b/src/main/java/org/jboss/pnc/api/dto/Request.java
@@ -34,6 +34,7 @@ import javax.validation.constraints.NotNull;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.jboss.pnc.api.constants.HttpHeaders.AUTHORIZATION_STRING;
 
@@ -52,14 +53,26 @@ public class Request {
 
     private final List<@Valid Header> headers;
 
+    /**
+     * Body of the request
+     */
     private final Object attachment;
 
+    /**
+     * Annotations are metadata that can influence the behaviour of the request beyond the HTTP method, url, and
+     * headers. For example, the code doing the request could apply changes to the attachment or headers based on the
+     * annotations.
+     * <p/>
+     * Annotations are dependent on how the client doing the request interprets those values.
+     */
+    private final Map<String, List<String>> annotations;
+
     public Request(Method method, URI uri) {
-        this(method, uri, new ArrayList<>(), null);
+        this(method, uri, new ArrayList<>(), null, null);
     }
 
     public Request(Method method, URI uri, List<Header> headers) {
-        this(method, uri, headers, null);
+        this(method, uri, headers, null, null);
     }
 
     public enum Method {

--- a/src/test/java/org/jboss/pnc/api/dto/RequestSerializationTest.java
+++ b/src/test/java/org/jboss/pnc/api/dto/RequestSerializationTest.java
@@ -25,10 +25,14 @@ import org.jboss.pnc.api.constants.HttpHeaders;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -45,6 +49,31 @@ class RequestSerializationTest {
 
         Request deserialized = objectMapper.readValue(serialized, Request.class);
         Assertions.assertEquals(Request.Method.GET, deserialized.getMethod());
+    }
+
+    @Test
+    public void shouldDeserializeRequestWithAnnotations() throws JsonProcessingException, URISyntaxException {
+        List<Request.Header> headers = new ArrayList<>();
+        headers.add(new Request.Header(HttpHeaders.AUTHORIZATION_STRING, "Bearer 12345"));
+        Map<String, List<String>> annotations = new HashMap<>();
+
+        List<String> abc = new ArrayList<>();
+        abc.add("1");
+        abc.add("2");
+
+        List<String> def = new ArrayList<>();
+        def.add("3");
+        def.add("4");
+
+        annotations.put("abc", abc);
+        annotations.put("def", def);
+
+        Request request = new Request(Request.Method.GET, new URI("http://localhost/"), headers, null, annotations);
+        String serialized = objectMapper.writeValueAsString(request);
+
+        Request deserialized = objectMapper.readValue(serialized, Request.class);
+        Assertions.assertEquals(Request.Method.GET, deserialized.getMethod());
+        Assertions.assertEquals(annotations, deserialized.getAnnotations());
     }
 
     @Test


### PR DESCRIPTION
This commit adds the 'annotations' field to the Request object. This isn't part of the actual request, but can be used to influence how the Request is built in the client processing it.

For example, the annotations could indicate that we need to add the authentication header in the request when it is processed by the client by defining the key 'AUTHENTICATION_HEADER_NEEDED' and leaving the value as an empty list.

It is a map with a key of String and as value a list of Strings. We didn't use a MultiValuedMap since Jackson cannot deserialize it properly out of the box.


@matejonnet @pkocandr @janinko @michalovjan  @vibe13 Let me know how you feel about this new field in the Request object.

I am adding it for my usecase: I want to tell Rex that I want to modify the attachment (aka body) so that it includes the previous step(s) results. The annotation will have something like:

```
REX_PREVIOUS_TASK_RESULTS: ["name of first task", "name of second task", ...]
```

The Rex client will act on that annotation to modify the attachment to include the results.

This is one way I figured I could do this, but if you have any other suggestions, please let me know! Thanks