### PR TITLE
[v2.4][NCLSUP-940] Rename isBrewPullActive to brewPullActive

### DIFF
--- a/src/main/java/org/jboss/pnc/api/repositorydriver/dto/RepositoryCreateRequest.java
+++ b/src/main/java/org/jboss/pnc/api/repositorydriver/dto/RepositoryCreateRequest.java
@@ -23,7 +23,7 @@ public class RepositoryCreateRequest {
     private final BuildType buildType;
     private final boolean tempBuild;
 
-    private final boolean isBrewPullActive;
+    private final boolean brewPullActive;
     private final List<String> extraRepositories;
 
 }


### PR DESCRIPTION
This make it more consistent and will confuse Jackson less.