### PR TITLE
[NCL-8068]: Update AnalysisResult DTO to use new DelAn API

### DIFF
--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalysisResult.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalysisResult.java
@@ -1,21 +1,24 @@
 package org.jboss.pnc.api.deliverablesanalyzer.dto;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.jackson.Jacksonized;
+
+import java.util.List;
 
 @Data
 @Jacksonized
 @Builder(builderClassName = "Builder")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AnalysisResult {
+
     @NonNull
-    private final String milestoneId;
+    private final String operationId;
+
     @NonNull
     private final List<FinderResult> results;
+
+    private final boolean scratch;
 }


### PR DESCRIPTION
The AnalysisResult DTO is sent to orchestrator (from BPM) when the Deliverable Analysis finishes in order to inform orchestrator to actually store analyzed artifacts in the DB.