### PR TITLE
[NCL-8250]: Add callback attribute into AnalysisResult

### DIFF
--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalysisResult.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/AnalysisResult.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.jackson.Jacksonized;
+import org.jboss.pnc.api.dto.Request;
 
 import java.util.List;
 
@@ -21,4 +22,7 @@ public class AnalysisResult {
     private final List<FinderResult> results;
 
     private final boolean scratch;
+
+    @NonNull
+    private final Request callback;
 }


### PR DESCRIPTION
This change is introduced since we want to make /operations/{id}/complete call asynchronous