### PR TITLE
[NCL-8681] - Add new deliverable analyzer DTOs

### DIFF
--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/Artifact.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/Artifact.java
@@ -78,6 +78,8 @@ public class Artifact {
 
     private final Collection<String> archiveUnmatchedFilenames;
 
+    private final Collection<LicenseInfo> licenses;
+
     public abstract static class ArtifactBuilder<C extends Artifact, B extends Artifact.ArtifactBuilder<C, B>> {
     }
 

--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/LicenseInfo.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/LicenseInfo.java
@@ -1,0 +1,47 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.api.deliverablesanalyzer.dto;
+
+import java.io.Serializable;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+
+@ToString
+@Getter
+@AllArgsConstructor
+@Jacksonized
+@Builder
+public class LicenseInfo implements Serializable {
+
+    private final String comments;
+
+    private final String distribution;
+
+    private final String name;
+
+    private final String url;
+
+    private String spdxLicenseId;
+
+    private LicenseSource source;
+
+}

--- a/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/LicenseSource.java
+++ b/src/main/java/org/jboss/pnc/api/deliverablesanalyzer/dto/LicenseSource.java
@@ -1,0 +1,22 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.api.deliverablesanalyzer.dto;
+
+public enum LicenseSource {
+    UNKNOWN, POM, POM_XML, BUNDLE_LICENSE, TEXT
+}


### PR DESCRIPTION
To store additional license information returned from Build Finder