### PR TITLE
[NCL-8743] relax Logfile md5 constraint for brewPush

### DIFF
--- a/src/main/java/org/jboss/pnc/api/causeway/dto/push/Logfile.java
+++ b/src/main/java/org/jboss/pnc/api/causeway/dto/push/Logfile.java
@@ -37,7 +37,6 @@ public class Logfile {
     @NonNull
     private final String deployPath;
     private final int size;
-    @NonNull
     private final String md5;
 
 }


### PR DESCRIPTION
Causeway computes checksums of every log so having it in request to Causeway is not necessary