### PR TITLE
[NCL-8808] Add userInitiator to the DTO request

### DIFF
--- a/src/main/java/org/jboss/pnc/api/causeway/dto/push/BuildImportRequest.java
+++ b/src/main/java/org/jboss/pnc/api/causeway/dto/push/BuildImportRequest.java
@@ -40,13 +40,17 @@ public class BuildImportRequest {
     private final Build build;
     private final boolean reimport;
 
+    private final String userInitiator;
+
     @JsonCreator
     public BuildImportRequest(
             @JsonProperty("callback") Request callback,
             @JsonProperty("build") Build build,
-            @JsonProperty("reimport") Boolean reimport) {
+            @JsonProperty("reimport") Boolean reimport,
+            @JsonProperty("userInitiator") String userInitiator) {
         this.callback = Objects.requireNonNull(callback, "Callback must be specified.");
         this.build = Objects.requireNonNull(build, "Build information must be specified.");
         this.reimport = reimport != null && reimport;
+        this.userInitiator = userInitiator;
     }
 }


### PR DESCRIPTION
The new field will be used to identify who initiated the Brew Push request, and add it as metadata in the Brew Push information. This is needed for auditing purposes.