### PR TITLE
[NCL-9113]: Allow AdjustRequest#originRepoUrl to be nullable

### DIFF
--- a/src/main/java/org/jboss/pnc/api/reqour/dto/AdjustRequest.java
+++ b/src/main/java/org/jboss/pnc/api/reqour/dto/AdjustRequest.java
@@ -15,7 +15,7 @@ import org.jboss.pnc.api.dto.HeartbeatConfig;
 import org.jboss.pnc.api.dto.Request;
 import org.jboss.pnc.api.enums.AlignmentPreference;
 import org.jboss.pnc.api.enums.BuildType;
-import org.jboss.pnc.api.reqour.dto.validation.GitRepositoryURL;
+import org.jboss.pnc.api.reqour.dto.validation.NullableGitRepositoryURL;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -57,7 +57,7 @@ public class AdjustRequest {
     /**
      * Git repository URL of the origin. May be nullable (in case there is not upstream present).
      */
-    @GitRepositoryURL
+    @NullableGitRepositoryURL
     String originRepoUrl;
 
     /**

--- a/src/main/java/org/jboss/pnc/api/reqour/dto/AdjustRequest.java
+++ b/src/main/java/org/jboss/pnc/api/reqour/dto/AdjustRequest.java
@@ -15,7 +15,7 @@ import org.jboss.pnc.api.dto.HeartbeatConfig;
 import org.jboss.pnc.api.dto.Request;
 import org.jboss.pnc.api.enums.AlignmentPreference;
 import org.jboss.pnc.api.enums.BuildType;
-import org.jboss.pnc.api.reqour.dto.validation.ValidGitRepositoryURL;
+import org.jboss.pnc.api.reqour.dto.validation.GitRepositoryURL;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -55,9 +55,9 @@ public class AdjustRequest {
     boolean sync;
 
     /**
-     * Git repository URL of the origin
+     * Git repository URL of the origin. May be nullable (in case there is not upstream present).
      */
-    @ValidGitRepositoryURL
+    @GitRepositoryURL
     String originRepoUrl;
 
     /**

--- a/src/main/java/org/jboss/pnc/api/reqour/dto/InternalGitRepositoryUrl.java
+++ b/src/main/java/org/jboss/pnc/api/reqour/dto/InternalGitRepositoryUrl.java
@@ -4,7 +4,7 @@
  */
 package org.jboss.pnc.api.reqour.dto;
 
-import org.jboss.pnc.api.reqour.dto.validation.ValidGitRepositoryURL;
+import org.jboss.pnc.api.reqour.dto.validation.GitRepositoryURL;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -24,12 +24,12 @@ public class InternalGitRepositoryUrl {
     /**
      * Git repository URL that you can use to clone anonymously
      */
-    @ValidGitRepositoryURL
+    @GitRepositoryURL
     String readonlyUrl;
 
     /**
      * Git repository URL that you can use for pushing of the content
      */
-    @ValidGitRepositoryURL
+    @GitRepositoryURL
     String readwriteUrl;
 }

--- a/src/main/java/org/jboss/pnc/api/reqour/dto/RepositoryCloneRequest.java
+++ b/src/main/java/org/jboss/pnc/api/reqour/dto/RepositoryCloneRequest.java
@@ -21,7 +21,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import org.jboss.pnc.api.dto.Request;
-import org.jboss.pnc.api.reqour.dto.validation.ValidGitRepositoryURL;
+import org.jboss.pnc.api.reqour.dto.validation.GitRepositoryURL;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -41,13 +41,13 @@ public class RepositoryCloneRequest {
     /**
      * Original repository to sync from
      */
-    @ValidGitRepositoryURL
+    @GitRepositoryURL
     String originRepoUrl;
 
     /**
      * Repository to sync to
      */
-    @ValidGitRepositoryURL
+    @GitRepositoryURL
     String targetRepoUrl;
 
     /**

--- a/src/main/java/org/jboss/pnc/api/reqour/dto/RepositoryCloneResponse.java
+++ b/src/main/java/org/jboss/pnc/api/reqour/dto/RepositoryCloneResponse.java
@@ -19,7 +19,7 @@ package org.jboss.pnc.api.reqour.dto;
 
 import javax.validation.constraints.NotNull;
 
-import org.jboss.pnc.api.reqour.dto.validation.ValidGitRepositoryURL;
+import org.jboss.pnc.api.reqour.dto.validation.GitRepositoryURL;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -39,13 +39,13 @@ public class RepositoryCloneResponse {
     /**
      * Original repository to sync from
      */
-    @ValidGitRepositoryURL
+    @GitRepositoryURL
     String originRepoUrl;
 
     /**
      * Repository to sync to
      */
-    @ValidGitRepositoryURL
+    @GitRepositoryURL
     String targetRepoUrl;
 
     /**

--- a/src/main/java/org/jboss/pnc/api/reqour/dto/TranslateRequest.java
+++ b/src/main/java/org/jboss/pnc/api/reqour/dto/TranslateRequest.java
@@ -17,7 +17,7 @@
  */
 package org.jboss.pnc.api.reqour.dto;
 
-import org.jboss.pnc.api.reqour.dto.validation.ValidGitRepositoryURL;
+import org.jboss.pnc.api.reqour.dto.validation.GitRepositoryURL;
 
 import lombok.Value;
 import lombok.experimental.NonFinal;
@@ -30,6 +30,6 @@ import lombok.extern.jackson.Jacksonized;
 @Jacksonized
 public class TranslateRequest {
 
-    @ValidGitRepositoryURL
+    @GitRepositoryURL
     String externalUrl;
 }

--- a/src/main/java/org/jboss/pnc/api/reqour/dto/validation/GitRepositoryURL.java
+++ b/src/main/java/org/jboss/pnc/api/reqour/dto/validation/GitRepositoryURL.java
@@ -27,13 +27,16 @@ import javax.validation.Constraint;
 import javax.validation.Payload;
 
 /**
- * Annotation inspired by {@link org.hibernate.validator.constraints.URL}.
+ * Constraint annotation validating repository URL, which should meet one of the following:<br/>
+ * - {@link Patterns.ScpLike#PATTERN}<br/>
+ * - {@link Patterns.NonScpLike#PATTERN}<br/>
+ * - {@link Patterns.FileLike#PATTERN}<br/>
  */
 @Documented
 @Constraint(validatedBy = GitRepositoryURLValidator.class)
 @Target({ ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ValidGitRepositoryURL {
+public @interface GitRepositoryURL {
 
     String message() default "Invalid URL of the git repository";
 

--- a/src/main/java/org/jboss/pnc/api/reqour/dto/validation/GitRepositoryURLValidator.java
+++ b/src/main/java/org/jboss/pnc/api/reqour/dto/validation/GitRepositoryURLValidator.java
@@ -28,9 +28,10 @@ import lombok.Builder;
 import lombok.Value;
 
 /**
- * Validates whether the provided URL is of the format {@link Patterns.NonScpLike} or {@link Patterns.ScpLike}.
+ * Validates whether the provided URL is of the format {@link Patterns.NonScpLike}, {@link Patterns.ScpLike}, or
+ * {@link Patterns.FileLike}.
  */
-public class GitRepositoryURLValidator implements ConstraintValidator<ValidGitRepositoryURL, String> {
+public class GitRepositoryURLValidator implements ConstraintValidator<GitRepositoryURL, String> {
 
     private String protocol;
     private String user;
@@ -40,7 +41,7 @@ public class GitRepositoryURLValidator implements ConstraintValidator<ValidGitRe
     private String repository;
 
     @Override
-    public void initialize(ValidGitRepositoryURL annotation) {
+    public void initialize(GitRepositoryURL annotation) {
         this.protocol = annotation.protocol();
         this.user = annotation.user();
         this.host = annotation.host();
@@ -111,7 +112,7 @@ public class GitRepositoryURLValidator implements ConstraintValidator<ValidGitRe
         return null;
     }
 
-    private boolean filledButNotMatchingParsed(String valueFromAnnotation, String parsedValue) {
+    static boolean filledButNotMatchingParsed(String valueFromAnnotation, String parsedValue) {
         return valueFromAnnotation != null && !valueFromAnnotation.isEmpty()
                 && !valueFromAnnotation.equals(parsedValue);
     }

--- a/src/main/java/org/jboss/pnc/api/reqour/dto/validation/NullableGitRepositoryURL.java
+++ b/src/main/java/org/jboss/pnc/api/reqour/dto/validation/NullableGitRepositoryURL.java
@@ -1,0 +1,56 @@
+package org.jboss.pnc.api.reqour.dto.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Same as {@link GitRepositoryURL}, but can be potentially nullable.
+ */
+@Documented
+@Constraint(validatedBy = NullableGitRepositoryURLValidator.class)
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NullableGitRepositoryURL {
+
+    String message() default "Invalid URL of the git repository";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * @return the protocol the annotated string must match, e.g. http. By default, any protocol is allowed.
+     */
+    String protocol() default "";
+
+    /**
+     * @return the user the annotated string must match, e.g. git. By default, any user is allowed.
+     */
+    String user() default "";
+
+    /**
+     * @return the host the annotated string must match, e.g. 'gitlab.cee.redhat.com'. By default, any host is allowed.
+     */
+    String host() default "";
+
+    /**
+     * @return the port the annotated string must match, e.g. 443. By default, any port is allowed.
+     */
+    int port() default -1;
+
+    /**
+     * @return the organization the annotated string must match, e.g. 'pnc'. By default, any organization is allowed.
+     */
+    String organization() default "";
+
+    /**
+     * @return the organization the annotated string must match, e.g. 'pnc-api'. By default, any repository is allowed.
+     */
+    String repository() default "";
+}

--- a/src/main/java/org/jboss/pnc/api/reqour/dto/validation/NullableGitRepositoryURLValidator.java
+++ b/src/main/java/org/jboss/pnc/api/reqour/dto/validation/NullableGitRepositoryURLValidator.java
@@ -1,0 +1,54 @@
+package org.jboss.pnc.api.reqour.dto.validation;
+
+import static org.jboss.pnc.api.reqour.dto.validation.GitRepositoryURLValidator.filledButNotMatchingParsed;
+import static org.jboss.pnc.api.reqour.dto.validation.GitRepositoryURLValidator.parseURL;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.jboss.pnc.api.dto.validation.DomainNameUtil;
+
+/**
+ * Same as {@link GitRepositoryURLValidator}, but allows the annotated string to be nullable.
+ */
+public class NullableGitRepositoryURLValidator implements ConstraintValidator<NullableGitRepositoryURL, String> {
+
+    private String protocol;
+    private String user;
+    private String host;
+    private int port;
+    private String organization;
+    private String repository;
+
+    @Override
+    public void initialize(NullableGitRepositoryURL annotation) {
+        this.protocol = annotation.protocol();
+        this.user = annotation.user();
+        this.host = annotation.host();
+        this.port = annotation.port();
+        this.organization = annotation.organization();
+        this.repository = annotation.repository();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        if (value.isEmpty()) {
+            return false;
+        }
+
+        GitRepositoryURLValidator.ParsedURL url = parseURL(value);
+        if (url == null || filledButNotMatchingParsed(protocol, url.getProtocol())
+                || filledButNotMatchingParsed(user, url.getUser()) || filledButNotMatchingParsed(host, url.getHost())
+                || !DomainNameUtil.isValidDomainAddress(url.getHost(), url.getProtocol())
+                || (port != -1 && port != url.getPort())
+                || filledButNotMatchingParsed(organization, url.getOrganization())
+                || filledButNotMatchingParsed(repository, url.getRepository())) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/org/jboss/pnc/api/reqour/dto/validation/GitRepositoryURLValidatorTest.java
+++ b/src/test/java/org/jboss/pnc/api/reqour/dto/validation/GitRepositoryURLValidatorTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class ValidGitRepositoryURLValidatorTest {
+public class GitRepositoryURLValidatorTest {
 
     private static ValidatorFactory validatorFactory;
     private static Validator validator;
@@ -52,47 +52,47 @@ public class ValidGitRepositoryURLValidatorTest {
 
     @Test
     public void validate_whenValidNonScpLikeExternalURL_returnsEmptyViolations() {
-        URLRequest request = new URLRequest("https://github.com/project/repo.git");
+        UrlRequest request = new UrlRequest("https://github.com/project/repo.git");
 
-        Set<ConstraintViolation<URLRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<UrlRequest>> violations = validator.validate(request);
 
         assertThat(violations).isEmpty();
     }
 
     @Test
     public void validate_whenValidScpLikeExternalURL_returnsEmptyViolations() {
-        URLRequest request = new URLRequest("git@github.com:project/repo.git");
+        UrlRequest request = new UrlRequest("git@github.com:project/repo.git");
 
-        Set<ConstraintViolation<URLRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<UrlRequest>> violations = validator.validate(request);
 
         assertThat(violations).isEmpty();
     }
 
     @Test
     public void validate_whenFileProtocol_returnsEmptyViolations() {
-        URLRequest request = new URLRequest("file:///tmp/foo/bar");
+        UrlRequest request = new UrlRequest("file:///tmp/foo/bar");
 
-        Set<ConstraintViolation<URLRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<UrlRequest>> violations = validator.validate(request);
 
         assertThat(violations).isEmpty();
     }
 
     @Test
     public void validate_whenInvalidExternalURL_returnsNonEmptyViolations() {
-        URLRequest request = new URLRequest("git@github.com/project/repo.git");
+        UrlRequest request = new UrlRequest("git@github.com/project/repo.git");
 
-        Set<ConstraintViolation<URLRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<UrlRequest>> violations = validator.validate(request);
 
         assertThat(violations).isNotEmpty();
     }
 
-    private static class URLRequest {
+    private static class UrlRequest {
 
-        @ValidGitRepositoryURL
-        private final String externalURL;
+        @GitRepositoryURL
+        private final String annotatedUrl;
 
-        public URLRequest(String externalURL) {
-            this.externalURL = externalURL;
+        public UrlRequest(String annotatedUrl) {
+            this.annotatedUrl = annotatedUrl;
         }
     }
 }

--- a/src/test/java/org/jboss/pnc/api/reqour/dto/validation/NullableGitRepositoryURLValidatorTest.java
+++ b/src/test/java/org/jboss/pnc/api/reqour/dto/validation/NullableGitRepositoryURLValidatorTest.java
@@ -1,0 +1,63 @@
+package org.jboss.pnc.api.reqour.dto.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class NullableGitRepositoryURLValidatorTest {
+
+    private static ValidatorFactory validatorFactory;
+    private static Validator validator;
+
+    @BeforeAll
+    public static void setUp() {
+        validatorFactory = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(new ParameterMessageInterpolator())
+                .buildValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        validatorFactory.close();
+    }
+
+    @Test
+    public void validate_whenNull_returnsEmptyViolations() {
+        UrlRequest request = new UrlRequest(null);
+
+        Set<ConstraintViolation<UrlRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void validate_whenValidNonScpLikeExternalURL_returnsEmptyViolations() {
+        UrlRequest request = new UrlRequest("https://github.com/project/repo.git");
+
+        Set<ConstraintViolation<UrlRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    private static class UrlRequest {
+
+        @NullableGitRepositoryURL
+        private final String annotatedUrl;
+
+        public UrlRequest(String annotatedUrl) {
+            this.annotatedUrl = annotatedUrl;
+        }
+    }
+}


### PR DESCRIPTION
This is the same as @GitRepositoryURL. However, unlike @GitRepositoryURL, such annotated string is allowed to be nullable, yet still valid.