### PR TITLE
Enforce Java 8 dependencies+downgrade openapi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <version.javax.ws.rs-api>2.1.1</version.javax.ws.rs-api>
         <version.javax.json.bind-api>1.0</version.javax.json.bind-api>
         <version.javax.validation-api>2.0.1.Final</version.javax.validation-api>
-        <version.microprofile-openapi-api>4.1.1</version.microprofile-openapi-api>
+        <version.microprofile-openapi-api>3.1.2</version.microprofile-openapi-api>
 
         <!-- Regular dependencies -->
         <version.lombok>1.18.46</version.lombok>
@@ -98,6 +98,7 @@
         <version.spotless-maven-plugin>3.9.0</version.spotless-maven-plugin>
         <version.pnc-ide-config>1.1.0</version.pnc-ide-config>
         <version.transformer-maven-plugin>1.0.0</version.transformer-maven-plugin>
+        <version.extra-enforcer-rules>1.8.0</version.extra-enforcer-rules>
 
         <!-- Override enforcer requirements -->
         <jdk.min.version>11</jdk.min.version>
@@ -177,6 +178,35 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>${version.extra-enforcer-rules}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>enforce-bytecode-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <enforceBytecodeVersion>
+                                    <maxJdkVersion>1.8</maxJdkVersion>
+                                    <ignoredScopes>
+                                        <ignoredScope>test</ignoredScope>
+                                    </ignoredScopes>
+                                </enforceBytecodeVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>


### PR DESCRIPTION
Thanks to @rnc for pointing out that microprofile-openapi was targetting Java 11 even though this library is targetting Java 8.

This commit uses the maven-enforcer-plugin to catch this issue.